### PR TITLE
fix: Bump UI assets version

### DIFF
--- a/packages/tldraw/setupTests.js
+++ b/packages/tldraw/setupTests.js
@@ -8,6 +8,8 @@ global.FontFace = class FontFace {
 	}
 }
 
+import { version } from './src/lib/ui/version'
+
 document.fonts = {
 	add: () => {},
 	delete: () => {},
@@ -35,7 +37,7 @@ Object.defineProperty(global.URL, 'createObjectURL', {
 })
 
 window.fetch = async (input, init) => {
-	if (input === 'https://unpkg.com/@bigbluebutton/assets@2.0.0-alpha.12/translations/en.json') {
+	if (input === `https://unpkg.com/@bigbluebutton/assets@${version}/translations/en.json`) {
 		const json = await import('@bigbluebutton/assets/translations/main.json')
 		return {
 			ok: true,

--- a/packages/tldraw/src/lib/ui/version.ts
+++ b/packages/tldraw/src/lib/ui/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0-alpha.12'
+export const version = '2.0.0-alpha.20'


### PR DESCRIPTION
Fixes the URL of publicly accessible assets, such as the fonts in https://github.com/bigbluebutton/tldraw/blob/27f8de16c7761323b54732fdf1c3244f4c0c3b8d/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts#L18 by bumping tldraw's UI version.

This enables external components such as `bbb-playback` to correctly resolve URLs, since, e.g., `@bigbluebutton/assets@2.0.0-alpha.12` does not exist.