### PR TITLE
fix: Disable edge scroll and pan tool click action zoom

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1271,6 +1271,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this.getInstanceState().openMenus
 	}
 
+	closeMenusOpen(): this {
+		if (this.getOpenMenus()?.length) this.updateInstanceState({ openMenus: [] });
+		return this;
+	}
+
 	/**
 	 * Add an open menu.
 	 *
@@ -8696,6 +8701,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 					switch (info.name) {
 						case 'pointer_down': {
+							this.closeMenusOpen();
 							this._selectedShapeIdsAtPointerDown = this.getSelectedShapeIds()
 
 							// Firefox bug fix...

--- a/packages/editor/src/lib/utils/edgeScrolling.ts
+++ b/packages/editor/src/lib/utils/edgeScrolling.ts
@@ -28,39 +28,40 @@ export function getEdgeProximityFactor(position: number, scrollOffset: number, e
  * @public
  */
 export function moveCameraWhenCloseToEdge(editor: Editor) {
-	if (!editor.inputs.isDragging || editor.inputs.isPanning) return
+	return;
+	// if (!editor.inputs.isDragging || editor.inputs.isPanning) return
 
-	const {
-		inputs: {
-			currentScreenPoint: { x, y },
-		},
-	} = editor
-	const zoomLevel = editor.getZoomLevel()
-	const screenBounds = editor.getViewportScreenBounds()
+	// const {
+	// 	inputs: {
+	// 		currentScreenPoint: { x, y },
+	// 	},
+	// } = editor
+	// const zoomLevel = editor.getZoomLevel()
+	// const screenBounds = editor.getViewportScreenBounds()
 
-	// Determines how far from the edges we start the scroll behaviour
-	const insetX = screenBounds.w < 1000 ? 40 : 32
-	const insetY = screenBounds.h < 1000 ? 40 : 32
+	// // Determines how far from the edges we start the scroll behaviour
+	// const insetX = screenBounds.w < 1000 ? 40 : 32
+	// const insetY = screenBounds.h < 1000 ? 40 : 32
 
-	// Determines how much the speed is affected by the screen size
-	const screenSizeFactorX = screenBounds.w < 1000 ? 0.612 : 1
-	const screenSizeFactorY = screenBounds.h < 1000 ? 0.612 : 1
+	// // Determines how much the speed is affected by the screen size
+	// const screenSizeFactorX = screenBounds.w < 1000 ? 0.612 : 1
+	// const screenSizeFactorY = screenBounds.h < 1000 ? 0.612 : 1
 
-	// Determines the base speed of the scroll
-	const pxSpeed = editor.user.getEdgeScrollSpeed() * EDGE_SCROLL_SPEED
+	// // Determines the base speed of the scroll
+	// const pxSpeed = editor.user.getEdgeScrollSpeed() * EDGE_SCROLL_SPEED
 
-	const proximityFactorX = getEdgeProximityFactor(x, insetX, screenBounds.w)
-	const proximityFactorY = getEdgeProximityFactor(y, insetY, screenBounds.h)
+	// const proximityFactorX = getEdgeProximityFactor(x, insetX, screenBounds.w)
+	// const proximityFactorY = getEdgeProximityFactor(y, insetY, screenBounds.h)
 
-	if (proximityFactorX === 0 && proximityFactorY === 0) return
+	// if (proximityFactorX === 0 && proximityFactorY === 0) return
 
-	const scrollDeltaX = (pxSpeed * proximityFactorX * screenSizeFactorX) / zoomLevel
-	const scrollDeltaY = (pxSpeed * proximityFactorY * screenSizeFactorY) / zoomLevel
+	// const scrollDeltaX = (pxSpeed * proximityFactorX * screenSizeFactorX) / zoomLevel
+	// const scrollDeltaY = (pxSpeed * proximityFactorY * screenSizeFactorY) / zoomLevel
 
-	const camera = editor.getCamera()
+	// const camera = editor.getCamera()
 
-	editor.setCamera({
-		x: camera.x + scrollDeltaX,
-		y: camera.y + scrollDeltaY,
-	})
+	// editor.setCamera({
+	// 	x: camera.x + scrollDeltaX,
+	// 	y: camera.y + scrollDeltaY,
+	// })
 }

--- a/packages/tldraw/src/lib/tools/HandTool/HandTool.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/HandTool.ts
@@ -10,31 +10,31 @@ export class HandTool extends StateNode {
 	static override children = () => [Idle, Pointing, Dragging]
 
 	override onDoubleClick: TLClickEvent = (info) => {
-		if (info.phase === 'settle') {
-			const { currentScreenPoint } = this.editor.inputs
-			this.editor.zoomIn(currentScreenPoint, { duration: 220, easing: EASINGS.easeOutQuint })
-		}
+		// if (info.phase === 'settle') {
+		// 	const { currentScreenPoint } = this.editor.inputs
+		// 	this.editor.zoomIn(currentScreenPoint, { duration: 220, easing: EASINGS.easeOutQuint })
+		// }
 	}
 
 	override onTripleClick: TLClickEvent = (info) => {
-		if (info.phase === 'settle') {
-			const { currentScreenPoint } = this.editor.inputs
-			this.editor.zoomOut(currentScreenPoint, { duration: 320, easing: EASINGS.easeOutQuint })
-		}
+		// if (info.phase === 'settle') {
+		// 	const { currentScreenPoint } = this.editor.inputs
+		// 	this.editor.zoomOut(currentScreenPoint, { duration: 320, easing: EASINGS.easeOutQuint })
+		// }
 	}
 
 	override onQuadrupleClick: TLClickEvent = (info) => {
-		if (info.phase === 'settle') {
-			const zoomLevel = this.editor.getZoomLevel()
-			const {
-				inputs: { currentScreenPoint },
-			} = this.editor
+		// if (info.phase === 'settle') {
+		// 	const zoomLevel = this.editor.getZoomLevel()
+		// 	const {
+		// 		inputs: { currentScreenPoint },
+		// 	} = this.editor
 
-			if (zoomLevel === 1) {
-				this.editor.zoomToFit({ duration: 400, easing: EASINGS.easeOutQuint })
-			} else {
-				this.editor.resetZoom(currentScreenPoint, { duration: 320, easing: EASINGS.easeOutQuint })
-			}
-		}
+		// 	if (zoomLevel === 1) {
+		// 		this.editor.zoomToFit({ duration: 400, easing: EASINGS.easeOutQuint })
+		// 	} else {
+		// 		this.editor.resetZoom(currentScreenPoint, { duration: 320, easing: EASINGS.easeOutQuint })
+		// 	}
+		// }
 	}
 }

--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -67,7 +67,7 @@ export const ContextMenu = function ContextMenu({ children }: { children: any })
 
 	const container = useContainer()
 
-	const [_, handleOpenChange] = useMenuIsOpen('context menu', cb)
+	const [isOpen, handleOpenChange] = useMenuIsOpen('context menu', cb)
 
 	// If every item in the menu is readonly, then we don't want to show the menu
 	const isReadonly = useReadonly()
@@ -85,7 +85,7 @@ export const ContextMenu = function ContextMenu({ children }: { children: any })
 	const disabled = !selectToolActive || noItemsToShow
 
 	return (
-		<_ContextMenu.Root dir="ltr" onOpenChange={handleOpenChange}>
+		<_ContextMenu.Root dir="ltr" onOpenChange={handleOpenChange} modal={false}>
 			<_ContextMenu.Trigger
 				onContextMenu={disabled ? preventDefault : undefined}
 				dir="ltr"
@@ -93,9 +93,7 @@ export const ContextMenu = function ContextMenu({ children }: { children: any })
 			>
 				{children}
 			</_ContextMenu.Trigger>
-			<_ContextMenu.Portal container={container}>
-				<ContextMenuContent />
-			</_ContextMenu.Portal>
+			{isOpen && <ContextMenuContent />}
 		</_ContextMenu.Root>
 	)
 }


### PR DESCRIPTION
This PR

- Disables the mouse edge scroll which was allowing users to activate the pan tool inadvertently. 
- Disables the pan tool click to zoom actions native to `tldraw`. 
- Closes open menus on pointer down event.

