### PR TITLE
fix: Update wheel event handling for zoom and pan behavior

### DIFF
--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -114,7 +114,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 			preventDefault(event)
 			const delta = normalizeWheel(event)
 
-			if (delta.x === 0 && delta.y === 0) return
+			if (delta.x === 0 && delta.y === 0 && delta.z === 0) return
 
 			const container = editor.getContainer().getBoundingClientRect()
 
@@ -129,6 +129,18 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 				shiftKey: event.shiftKey,
 				altKey: event.altKey,
 				ctrlKey: event.metaKey || event.ctrlKey,
+			}
+
+			// Custom behavior: Default to zooming unless modifiers are pressed
+			if (!event.ctrlKey && !event.shiftKey) {
+				// Default behavior: Zoom
+				info.delta = { x: 0, y: 0, z: delta.y }
+			} else if (event.ctrlKey) {
+				// Pan up/down with Ctrl
+				info.delta = { x: 0, y: delta.y, z: 0 }
+			} else if (event.shiftKey) {
+				// Pan left/right with Shift
+				info.delta = { x: delta.x, y: 0, z: 0 }
 			}
 
 			editor.dispatch(info)

--- a/packages/editor/src/lib/utils/normalizeWheel.ts
+++ b/packages/editor/src/lib/utils/normalizeWheel.ts
@@ -11,22 +11,26 @@ export function normalizeWheel(event: WheelEvent | React.WheelEvent<HTMLElement>
 	let { deltaY, deltaX } = event
 	let deltaZ = 0
 
-	if (event.ctrlKey || event.altKey || event.metaKey) {
-		const signY = Math.sign(event.deltaY)
-		const absDeltaY = Math.abs(event.deltaY)
+	if (!event.ctrlKey && !event.altKey && !event.metaKey) {
+		// No modifier key pressed - Zoom in/out
+		const signY = Math.sign(deltaY)
+		const absDeltaY = Math.abs(deltaY)
 
 		let dy = deltaY
-
 		if (absDeltaY > MAX_ZOOM_STEP) {
 			dy = MAX_ZOOM_STEP * signY
 		}
 
-		deltaZ = dy / 100
-	} else {
-		if (event.shiftKey && !IS_DARWIN) {
-			deltaX = deltaY
-			deltaY = 0
-		}
+		deltaZ = dy / 100;
+		deltaX = 0
+		deltaY = 0
+	} else if (event.ctrlKey || event.altKey || event.metaKey) {
+		// Ctrl/Alt/Meta key pressed - Pan vertically (up/down)
+		deltaZ = 0
+	} else if (event.shiftKey && !IS_DARWIN) {
+		// Shift + Scroll = Pan horizontally (left/right)
+		deltaX = deltaY
+		deltaY = 0
 	}
 
 	return { x: -deltaX, y: -deltaY, z: -deltaZ }


### PR DESCRIPTION
This PR updates the wheel event handling to support default zooming without modifiers, vertical panning with Ctrl, and horizontal panning with Shift.