### PR TITLE
Update fallback error message to point to BigBlueButton support

### DIFF
--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -162,8 +162,7 @@ My browser: ${navigator.userAgent}`
 						<h2>Something&apos;s gone wrong.</h2>
 						<p>
 							Sorry, we encountered an error. Please refresh the page to continue. If you keep
-							seeing this error, you can <a href={url.toString()}>create a GitHub issue</a> or{' '}
-							<a href="https://discord.gg/Cq6cPsTfNy">ask for help on Discord</a>.
+							seeing this error, you can <a href="https://github.com/bigbluebutton/bigbluebutton/issues">create a GitHub issue</a> for support.
 						</p>
 						{shouldShowError && (
 							<div className="tl-error-boundary__content__error">


### PR DESCRIPTION
Updated the default fallback error message to direct users to BigBlueButton GitHub issues page for support, instead of the tldraw GitHub and Discord links