### PR TITLE
fix: Remove decimals from poll results

### DIFF
--- a/packages/tldraw/src/lib/shapes/poll/components/poll-content.tsx
+++ b/packages/tldraw/src/lib/shapes/poll/components/poll-content.tsx
@@ -88,7 +88,7 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
 			<Styled.PollText>{pollData.questionText}</Styled.PollText>
 			<ResponsiveContainer width="90%" height={useHeight}>
 				<BarChart data={translatedAnswers} layout="vertical">
-					<XAxis type="number" />
+					<XAxis type="number" allowDecimals={false} />
 					<YAxis width={80} type="category" dataKey="pollAnswer" />
 					<Bar dataKey="numVotes" fill="#0C57A7" />
 				</BarChart>


### PR DESCRIPTION
This is a follow up to [Fix: Remove polls Decimals](https://github.com/bigbluebutton/bigbluebutton/pull/21634#top)
, removing decimals from the poll results.