### PR TITLE
Move highlight tool higher in the schema list

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -85,7 +85,7 @@ jobs:
         run: 'xvfb-run yarn e2e'
         working-directory: apps/examples
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -47,7 +47,7 @@ export const Toolbar = memo(function Toolbar() {
 		const itemsInDropdown: TLUiToolbarItem[] = []
 		let dropdownFirstItem: TLUiToolbarItem | undefined
 
-		const overflowIndex = Math.min(8, 5 + breakpoint)
+		const overflowIndex = Math.min(9, 6 + breakpoint)
 
 		for (let i = 4; i < toolbarItems.length; i++) {
 			const item = toolbarItems[i]

--- a/packages/tldraw/src/lib/ui/hooks/useToolbarSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useToolbarSchema.tsx
@@ -46,6 +46,7 @@ export function ToolbarSchemaProvider({ overrides, children }: TLUiToolbarSchema
 		const schema: TLUiToolbarSchemaContextType = compact([
 			toolbarItem(tools.select),
 			toolbarItem(tools.hand),
+			toolbarItem(tools.highlight),
 			toolbarItem(tools.draw),
 			toolbarItem(tools.eraser),
 			toolbarItem(tools.arrow),
@@ -70,7 +71,6 @@ export function ToolbarSchemaProvider({ overrides, children }: TLUiToolbarSchema
 			toolbarItem(tools['arrow-down']),
 			toolbarItem(tools['arrow-right']),
 			toolbarItem(tools.line),
-			toolbarItem(tools.highlight),
 			toolbarItem(tools.frame),
 			toolbarItem(tools.laser),
 		])


### PR DESCRIPTION
This PR repositions the highlight tool in the toolbar schema list to make it visible in the main toolbar instead of being hidden in the dropdown menu.