### PR TITLE
fix: Remove isToolLocked check from note shape

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
@@ -140,7 +140,7 @@ describe('When in the pointing state', () => {
 		editor.setCurrentTool('note')
 		editor.pointerDown(50, 50)
 		editor.pointerUp(50, 50)
-		editor.expectToBeIn('note.idle')
+		editor.expectToBeIn('select.editing_shape')
 		expect(editor.getCurrentPageShapes().length).toBe(1)
 	})
 })

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -65,16 +65,12 @@ export class Pointing extends StateNode {
 
 	private complete() {
 		if (this.wasFocusedOnEnter) {
-			if (this.editor.getInstanceState().isToolLocked) {
-				this.parent.transition('idle')
-			} else {
-				this.editor.setEditingShape(this.shape.id)
-				this.editor.setCurrentTool('select.editing_shape', {
-					...this.info,
-					target: 'shape',
-					shape: this.shape,
-				})
-			}
+			this.editor.setEditingShape(this.shape.id)
+			this.editor.setCurrentTool('select.editing_shape', {
+				...this.info,
+				target: 'shape',
+				shape: this.shape,
+			})
 		}
 	}
 


### PR DESCRIPTION
This PR removes the tool lock check from the note shape to make its behavior more consistent with the text tool during shape creation.

Related to [fix(whiteboard): Lock selected tool to prevent automatic switching to select mode](https://github.com/bigbluebutton/bigbluebutton/pull/22624#top).
